### PR TITLE
Adiciona: Liga de instâncias lusófonas de esquerda do fediverso (LILEF)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,28 @@
-# Fediverso Seguro
+Liga de instâncias lusófonas de esquerda do fediverso (LILEF)
+-----
 
-Uma lista de instâncias do Fediverso que compartilham o mesmo conjunto de regras.
+A ideia da liga de instâncias lusófonas de esquerda é de aproximar as instâncias e facilitar a colaboração entre elas. Toda instância participante da liga é uma instância independente, mas para participar da liga precisa obedecer a um conjunto de regras base que serve para facilitar a interação entre as instâncias participantes.
+
+A motivação para a criação da liga é o fortalecimento da colaboração entre instâncias mas também de fomentar novas instâncias que falam português que vão ter uma barreira menor de entrada por ter algumas ferramentas que vão facilitar sua chegada (dentre elas, uma base de regras a utilizar, suporte de outres admins e mods das outras instâncias da liga e afins).
+
+Para fins desse documento, um membro é uma instância. Uma instância é considerada como um domínio e seus administradores e moderadores. Dois domínios diferentes com o mesmo conjunto de administradores e moderadores são considerados como a mesma instância.
+
+Novos membros da liga são aceitos por meio de votação dos membros existentes com maioria simples [^1]. Instâncias podem ser propostas por membros existentes, ou se candidatar de maneira espontânea. Instâncias não aceitas podem se recandidatar novamente após 3 meses. Instâncias ao serem rejeitadas podem ter um retorno sobre o motivo que levou a sua não-aceitação.
+
+Mudanças nas regras da liga são feitas por meio de moção entre os membros e deve ser aprovada por maioria absoluta [^2].
+
+Membros da liga serão removidos se não obedecerem as regras base. Outros membros podem começar uma votação para remover membros da liga por outros motivos, e membros serão removidos no caso de uma maioria absoluta de $2/3$.
+
+Moderadores e administradores podem igualmente participar de discussões, mas cada instância-membro tem direito à um voto. Por isso, para todas as decisões, a instância deve primeiro chegar a um acordo interno antes de colocar sua posição para a liga.
+
+Instâncias da liga são aconselhadas a terem menos de 1000 membros, mas devem manter uma proporção de 1 moderador/admin para cada 100 membros ativos[^3]. Instâncias da liga **não podem** ter mais que 5000 membros.
+
+A liga oferece um relay [^4] que as instâncias participantes podem, opcionalmente, utilizar. O relay facilita a interação entre membros das instâncias participantes. A liga também oferece um fork do Mastodon que disponibiliza uma timeline especial, da liga, que permite ver os posts dos participantes da liga, no mesmo estilo da timeline local.
+
+[^1]: Maioria simples: A maioria dos membros presentes. No caso em que hajam 10 instâncias presentes na liga num dado momento mas que apenas 4 estejam presentes na reunião, 3 $(4/2 + 1)$ votos são suficientes para aprovação. 
+
+[^2]: Maioria absoluta: A maioria dos membros. No caso em que hajam 10 instâncias presentas num dado momento, é necessário 6 $(10/2 + 1)$ votos para aprovação.
+
+[^3]: Usuáries atives aqui usa a definição da página de entrada do Mastodon. Aceita-se um período de transição de até 2 semanas quando a instância estiver em fase de crescimento onde esse limite pode ser passado, até que se encontre novas pessoas para ajudar na moderação. O importante é que mesmo nesse período a instância não esteja "abandonada" em termos de moderação.
+
+[^4]: Relay: Um software que republica mensagens públicas entre instâncias diferentes. Instâncias que estejam inscritas no mesmo relay enviam seus toots públicos ao relay e recebem de volta todos os toots públicos de outras instâncias do relay.


### PR DESCRIPTION
Ideia inicialmente do Renato Lond, admin da masto.donte.com.br.

Original em: https://gist.github.com/renatolond/f01f15c38c5220d8aa14ed2c239aac04